### PR TITLE
Fix exit method to use sys.exit for proper cleanup

### DIFF
--- a/RNS/__init__.py
+++ b/RNS/__init__.py
@@ -382,7 +382,7 @@ def exit(code=0):
     if not exit_called:
         exit_called = True
         Reticulum.exit_handler()
-        os._exit(code)
+        sys.exit(code)
 
 class Profiler:
     _ran = False


### PR DESCRIPTION
Change `RNS.__init__.py` exit method from `os._exit` to `sys.exit` to allow proper cleanup and exception handling. Keep `panic` method using `os._exit` for immediate termination in unrecoverable scenarios.

Resolves https://github.com/markqvist/Reticulum/issues/822